### PR TITLE
remote socket and core check

### DIFF
--- a/pkg/collectors/managedclusterinfo.go
+++ b/pkg/collectors/managedclusterinfo.go
@@ -73,9 +73,7 @@ func getManagedClusterInfoMetricFamilies(hubClusterID string, clusterclient *clu
 				if clusterID == "" ||
 					kubeVendor == "" ||
 					cloudVendor == "" ||
-					version == "" ||
-					core_worker == 0 ||
-					socket_worker == 0 {
+					version == "" {
 					klog.Infof("Not enough information available for %s", obj.GetName())
 					klog.Infof(`\tClusterID=%s,
 KubeVendor=%s,

--- a/pkg/collectors/managedclusterinfo_test.go
+++ b/pkg/collectors/managedclusterinfo_test.go
@@ -113,6 +113,34 @@ func Test_getManagedClusterMetricFamilies(t *testing.T) {
 		},
 	}
 
+	mcZeroInfo := &mcv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hive-cluster-3",
+			Annotations: map[string]string{
+				"open-cluster-management/created-via": "hive",
+			},
+			Labels: map[string]string{
+				mciv1beta1.OCPVersion:       "4.3.1",
+				mciv1beta1.LabelKubeVendor:  string(mciv1beta1.KubeVendorOpenShift),
+				mciv1beta1.LabelCloudVendor: string(mciv1beta1.CloudVendorAWS),
+				mciv1beta1.LabelClusterID:   "managed_cluster_id",
+			},
+		},
+		Status: mcv1.ManagedClusterStatus{
+			Capacity: mcv1.ResourceList{
+				resourceCoreWorker:   *resource.NewQuantity(0, resource.DecimalSI),
+				resourceSocketWorker: *resource.NewQuantity(0, resource.DecimalSI),
+			},
+			ClusterClaims: []mcv1.ManagedClusterClaim{
+				{
+					Name:  "kubeversion.open-cluster-management.io",
+					Value: "v1.16.2",
+				},
+			},
+			Conditions: []metav1.Condition{},
+		},
+	}
+
 	envTest := setupEnvTest(t)
 	clusterClient, err := clusterclient.NewForConfig(envTest.Config)
 	if err != nil {
@@ -134,6 +162,11 @@ func Test_getManagedClusterMetricFamilies(t *testing.T) {
 			Obj:         mcMissingInfo,
 			MetricNames: []string{"acm_managed_cluster_info"},
 			Want:        "",
+		},
+		{
+			Obj:         mcZeroInfo,
+			MetricNames: []string{"acm_managed_cluster_info"},
+			Want:        `acm_managed_cluster_info{cloud="Amazon",core_worker="0",managed_cluster_id="managed_cluster_id",created_via="Hive",hub_cluster_id="mycluster_id",socket_worker="0",available="Unknown",vendor="OpenShift",version="4.3.1"} 1`,
 		},
 		{
 			Obj:         mcOther,

--- a/test/functional/managedclusterinfo_test.go
+++ b/test/functional/managedclusterinfo_test.go
@@ -17,18 +17,22 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	mcv1 "open-cluster-management.io/api/cluster/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+	mcv1 "open-cluster-management.io/api/cluster/v1"
 )
 
 const (
 	clusterDeploymentResponse = `# HELP acm_managed_cluster_info Managed cluster information
 # TYPE acm_managed_cluster_info gauge
+acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="hive_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Hive",core_worker="0",socket_worker="0"} 1
+acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="import_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Other",core_worker="0",socket_worker="0"} 1
+acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="local_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Other",core_worker="0",socket_worker="0"} 1
 `
 	managedClusterResponse = `# HELP acm_managed_cluster_info Managed cluster information
 # TYPE acm_managed_cluster_info gauge
+acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="hive_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Hive",core_worker="0",socket_worker="0"} 1
 acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="import_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Other",core_worker="2",socket_worker="1"} 1
 acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="local_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Other",core_worker="2",socket_worker="1"} 1
 `
@@ -36,6 +40,8 @@ acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",m
 	managedClusterHiveResponse = `# HELP acm_managed_cluster_info Managed cluster information
 # TYPE acm_managed_cluster_info gauge
 acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="hive_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Hive",core_worker="2",socket_worker="1"} 1
+acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="import_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Other",core_worker="0",socket_worker="0"} 1
+acm_managed_cluster_info{hub_cluster_id="787e5a35-c911-4341-a2e7-65c415147aeb",managed_cluster_id="local_cluster_id",vendor="OpenShift",cloud="Amazon",version="4.3.1",available="Unknown",created_via="Other",core_worker="0",socket_worker="0"} 1
 `
 )
 
@@ -214,7 +220,8 @@ func getMetrics() (resp *http.Response, bodyString string, err error) {
 }
 
 func updateMCStatus(name string, status mcv1.ManagedClusterStatus) error {
-	mcU, err := clientDynamic.Resource(gvrManagedcluster).Get(context.TODO(), name, metav1.GetOptions{})
+	mcU, err := clientDynamic.Resource(gvrManagedcluster).
+		Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ref: https://github.com/stolostron/backlog/issues/21502

This check is added by https://github.com/stolostron/clusterlifecycle-state-metrics/pull/43, as in the previous version, if a record is incomplete, the sum of metrics record would be incorrect. This issue has already been fixed in PR https://github.com/stolostron/clusterlifecycle-state-metrics/pull/62

On ocp 311, there's no prometheus installed, socket and core will always be 0 and no `acm_managed_cluster_info` generated. So remove this check to generate `acm_managed_cluster_info`

Signed-off-by: haoqing0110 <qhao@redhat.com>