### PR TITLE
fix(KONFLUX-3663): format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/clusterlifecycle-state-metrics-1tww-pull-request.yaml
+++ b/.tekton/clusterlifecycle-state-metrics-1tww-pull-request.yaml
@@ -281,8 +281,12 @@ spec:
         params:
           - name: SNYK_SECRET
             value: $(params.snyk-secret)
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           bundle: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:5aa816e7d7f5e03448d658edfeb26e086aa8a2102c4c3c1113651cf5ccfe55b1
           name: sast-snyk-check

--- a/.tekton/clusterlifecycle-state-metrics-1tww-push.yaml
+++ b/.tekton/clusterlifecycle-state-metrics-1tww-push.yaml
@@ -278,8 +278,12 @@ spec:
         params:
           - name: SNYK_SECRET
             value: $(params.snyk-secret)
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           bundle: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.1@sha256:5aa816e7d7f5e03448d658edfeb26e086aa8a2102c4c3c1113651cf5ccfe55b1
           name: sast-snyk-check


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for
long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263