### PR TITLE
replace the non-word characters or first digit with underscores and print warning message

### DIFF
--- a/pkg/generators/cluster/managedclusterlabels_test.go
+++ b/pkg/generators/cluster/managedclusterlabels_test.go
@@ -46,6 +46,23 @@ func Test_getManagedClusterLabelMetricFamilies(t *testing.T) {
 		},
 	}
 
+	mc3 := &mcv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster-3",
+			Labels: map[string]string{
+				mciv1beta1.LabelClusterID: "managed_cluster_id",
+				"5g-dev01-cluster":        "value1",
+				"55g//dev01__cluster":     "value2",
+				"_5g-dev01_cluster":       "value3",
+			},
+		},
+		Status: mcv1.ManagedClusterStatus{
+			Capacity:      mcv1.ResourceList{},
+			ClusterClaims: []mcv1.ManagedClusterClaim{},
+			Conditions:    []metav1.Condition{},
+		},
+	}
+
 	tests := []testcommon.GenerateMetricsTestCase{
 		{
 			Name:        "test cluster label",
@@ -58,6 +75,12 @@ func Test_getManagedClusterLabelMetricFamilies(t *testing.T) {
 			Obj:         mc2,
 			MetricNames: []string{"acm_managed_cluster_labels"},
 			Want:        `acm_managed_cluster_labels{cloud="Amazon",managed_cluster_id="managed_cluster_id",hub_cluster_id="hub_cluster_id",vendor="OpenShift"} 1`,
+		},
+		{
+			Name:        "test cluster3 label",
+			Obj:         mc3,
+			MetricNames: []string{"acm_managed_cluster_labels"},
+			Want:        `acm_managed_cluster_labels{managed_cluster_id="managed_cluster_id",hub_cluster_id="hub_cluster_id",_5g_dev01_cluster="value1",_55g_dev01__cluster="value2",_5g_dev01_cluster="value3"} 1`,
 		},
 	}
 


### PR DESCRIPTION
Fix https://issues.redhat.com/browse/ACM-14296 

```
oc logs clusterlifecycle-state-metrics-v2-7c8968d85d-g2kdh | grep W0
W0918 08:42:29.812111       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W0918 08:42:29.924393       1 managedclusterlabels.go:53] Label key 'cluster.open-cluster-management.io/clusterset' was modified to 'cluster_open_cluster_management_io_clusterset'
W0918 08:42:29.924445       1 managedclusterlabels.go:53] Label key 'velero.io/exclude-from-backup' was modified to 'velero_io_exclude_from_backup'
W0918 08:42:29.924484       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-application-manager' was modified to 'feature_open_cluster_management_io_addon_application_manager'
W0918 08:42:29.924537       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-cert-policy-controller' was modified to 'feature_open_cluster_management_io_addon_cert_policy_controller'
W0918 08:42:29.924590       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-managed-serviceaccount' was modified to 'feature_open_cluster_management_io_addon_managed_serviceaccount'
W0918 08:42:29.924650       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-work-manager' was modified to 'feature_open_cluster_management_io_addon_work_manager'
W0918 08:42:29.924685       1 managedclusterlabels.go:53] Label key 'openshiftVersion-major-minor' was modified to 'openshiftVersion_major_minor'
W0918 08:42:29.924748       1 managedclusterlabels.go:53] Label key '5g-test' was modified to '_5g_test'
W0918 08:42:29.924794       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-config-policy-controller' was modified to 'feature_open_cluster_management_io_addon_config_policy_controller'
W0918 08:42:29.924861       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-governance-policy-framework' was modified to 'feature_open_cluster_management_io_addon_governance_policy_framework'
W0918 08:42:29.924906       1 managedclusterlabels.go:53] Label key 'local-cluster' was modified to 'local_cluster'
W0918 08:42:29.924977       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-cluster-proxy' was modified to 'feature_open_cluster_management_io_addon_cluster_proxy'
W0918 08:42:29.925037       1 managedclusterlabels.go:53] Label key 'feature.open-cluster-management.io/addon-hypershift-addon' was modified to 'feature_open_cluster_management_io_addon_hypershift_addon'
W0918 08:42:29.925088       1 managedclusterlabels.go:53] Label key 'openshiftVersion-major' was modified to 'openshiftVersion_major'
```