### PR TITLE
remove unused dependencies

### DIFF
--- a/build/install-dependencies.sh
+++ b/build/install-dependencies.sh
@@ -3,20 +3,13 @@
 # Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-export GO111MODULE=off
-
 # Go tools
 _OS=$(go env GOOS)
 _ARCH=$(go env GOARCH)
 KubeBuilderVersion="2.3.0"
 
-if ! which patter > /dev/null; then      echo "Installing patter ..."; go get -u github.com/apg/patter; fi
-if ! which gocovmerge > /dev/null; then  echo "Installing gocovmerge..."; go get -u github.com/wadey/gocovmerge; fi
-if ! which go-bindata > /dev/null; then
-	echo "Installing go-bindata..."
-	cd $(mktemp -d) && GOSUMDB=off go get -u github.com/go-bindata/go-bindata/...
-fi
-go-bindata --version
+if ! which patter > /dev/null; then      echo "Installing patter ..."; go install github.com/apg/patter@latest; fi
+if ! which gocovmerge > /dev/null; then  echo "Installing gocovmerge..."; go install -mod=mod github.com/wadey/gocovmerge; fi
 
 # Build tools
 if ! which kubebuilder > /dev/null; then

--- a/build/run-functional-tests.sh
+++ b/build/run-functional-tests.sh
@@ -27,17 +27,11 @@ if ! which kind > /dev/null; then
 fi
 if ! which ginkgo > /dev/null; then
     echo "Installing ginkgo ..."
-    pushd $(mktemp -d)
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.3.1
-    echo "installing gomega ..."
-    GO111MODULE=off go get github.com/onsi/gomega/...
-    popd
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.1
 fi
 if ! which gocovmerge > /dev/null; then
     echo "Installing gocovmerge..."
-    pushd $(mktemp -d)
-    go install github.com/wadey/gocovmerge@latest
-    popd
+    go install -mod=mod github.com/wadey/gocovmerge
 fi
 if ! which helm > /dev/null; then
     echo "Installing helm..."

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -578,6 +578,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,6 +214,8 @@ github.com/stolostron/library-go/pkg/apis/meta/v1/deployment
 github.com/stolostron/library-go/pkg/client
 github.com/stolostron/library-go/pkg/config
 github.com/stolostron/library-go/pkg/templateprocessor
+# github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
+## explicit
 # go.uber.org/atomic v1.9.0
 ## explicit; go 1.13
 go.uber.org/atomic


### PR DESCRIPTION
Refer to the [go 1.22 release notes](https://tip.golang.org/doc/go1.22)
> go get is no longer supported outside of a module in the legacy GOPATH mode (that is, with GO111MODULE=off). Other build commands, such as go build and go test, will continue to work indefinitely for legacy GOPATH programs.

Before upgrading to 1.22, this PR is to remove `GO111MODULE=off` and replace go get with go install for dependencies, since the [release](https://github.com/openshift/release/pull/56897) repo reports the below [error](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/56897/rehearse-56897-pull-ci-stolostron-clusterlifecycle-state-metrics-backplane-2.7-unit/1836599241074544640) when just upgrading the golang version to 1.22. 
```
INFO[2024-09-19T02:18:00Z] which: no kustomize in (/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin)
which: no patter in (/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin:/usr/local/kubebuilder/bin)
Installing patter ...
go: modules disabled by GO111MODULE=off; see 'go help modules'
make: *** [Makefile:42: dependencies] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:84","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2024-09-19T02:17:59Z"} 
INFO[2024-09-19T02:[18](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/56897/rehearse-56897-pull-ci-stolostron-clusterlifecycle-state-metrics-backplane-2.7-check/1836587508071141376#1:build-log.txt%3A18):00Z] Ran for 11m55s                               
ERRO[2024-09-19T02:18:00Z] Some steps failed:                           
ERRO[2024-09-19T02:18:00Z] 
  * could not run steps: step check failed: test "check" failed: could not watch pod: the pod ci-op-psb715dd/check failed after 27s (failed containers: test): ContainerFailed one or more containers exited
  *
```

