### PR TITLE
Add multiarch build support to Tekton pipelines

### DIFF
--- a/.tekton/clusterlifecycle-state-metrics-mce-29-pull-request.yaml
+++ b/.tekton/clusterlifecycle-state-metrics-mce-29-pull-request.yaml
@@ -30,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.rhtap
   - name: path-context
@@ -113,6 +116,9 @@ spec:
       type: string
     - default:
       - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/clusterlifecycle-state-metrics-mce-29-push.yaml
+++ b/.tekton/clusterlifecycle-state-metrics-mce-29-push.yaml
@@ -27,6 +27,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: build/Dockerfile.rhtap
   - name: path-context
@@ -110,6 +113,9 @@ spec:
       type: string
     - default:
       - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms


### PR DESCRIPTION
This PR adds multiarch build support to the Tekton pipeline configurations by adding support for linux/arm64, linux/ppc64le, and linux/s390x platforms in addition to the existing linux/x86_64 platform. Changes include: - Updated build-platforms parameter in both pull request and push pipeline configurations - Updated default values for build-platforms parameter in pipeline specs - Enables building container images for multiple architectures