### PR TITLE
Change klog.Infof to klog.V(4).Infof for verbose logging

### DIFF
--- a/pkg/generators/addon/managedclusteraddonstatus.go
+++ b/pkg/generators/addon/managedclusteraddonstatus.go
@@ -49,7 +49,7 @@ func GetManagedClusterAddOnStatusMetricFamilies(getClusterIdFunc func(string) st
 				requiredAddOnStatusConditions,
 				getAllowedAddOnConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return &f
 		},
 	}

--- a/pkg/generators/cluster/managedclustercount.go
+++ b/pkg/generators/cluster/managedclustercount.go
@@ -30,7 +30,7 @@ func GetManagedClusterCountMetricFamilies() metric.FamilyGenerator {
 					Value: float64(count),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/cluster/managedclusterinfo.go
+++ b/pkg/generators/cluster/managedclusterinfo.go
@@ -120,7 +120,7 @@ product=%s`,
 					Value:       1,
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterlabels.go
+++ b/pkg/generators/cluster/managedclusterlabels.go
@@ -76,7 +76,7 @@ func GetManagedClusterLabelMetricFamilies(hubClusterID string) metric.FamilyGene
 				},
 			}}
 
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterstatus.go
+++ b/pkg/generators/cluster/managedclusterstatus.go
@@ -43,7 +43,7 @@ func GetManagedClusterStatusMetricFamilies() metric.FamilyGenerator {
 				requiredClusterStatusConditions,
 				getAllowedClusterConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclustertimestamp.go
+++ b/pkg/generators/cluster/managedclustertimestamp.go
@@ -43,7 +43,7 @@ func GetManagedClusterTimestampMetricFamilies(hubClusterID string,
 				values,
 				getClusterTimestamps,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterworkercores.go
+++ b/pkg/generators/cluster/managedclusterworkercores.go
@@ -55,7 +55,7 @@ core_worker=%d`,
 					Value:       float64(core_worker),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/work/manifestworkcount.go
+++ b/pkg/generators/work/manifestworkcount.go
@@ -29,7 +29,7 @@ func GetManifestWorkCountMetricFamilies() metric.FamilyGenerator {
 					Value: float64(count),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/work/manifestworkstatus.go
+++ b/pkg/generators/work/manifestworkstatus.go
@@ -50,7 +50,7 @@ func GetManifestWorkStatusMetricFamilies(getClusterIdFunc func(string) string) m
 				requiredWorkStatusConditions,
 				getAllowedManifestWorkConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return &f
 		},
 	}

--- a/pkg/generators/work/manifestworktimestamp.go
+++ b/pkg/generators/work/manifestworktimestamp.go
@@ -58,7 +58,7 @@ func GetManifestWorkTimestampMetricFamilies(getClusterIdFunc func(string) string
 					keys, values, generators.AppliedTimestamp))
 			}
 
-			klog.Infof("Returning %v", string(family.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(family.ByteSlice()))
 			return &family
 		},
 	}


### PR DESCRIPTION
## Summary
- Updated all klog.Infof("Returning %v", string(f.ByteSlice())) statements to use klog.V(4).Infof for verbose logging
- This reduces the verbosity of these log messages from default info level to verbose level 4
- Improves log cleanliness in production environments

## Test plan
- [x] Search and replace all occurrences of the specific klog.Infof pattern
- [x] Verify no old patterns remain in the codebase
- [x] Code compiles successfully

🤖 Generated with [Claude Code](https://claude.ai/code)