### PR TITLE
Update klog verbosity level for debug output

### DIFF
--- a/pkg/generators/addon/managedclusteraddonstatus.go
+++ b/pkg/generators/addon/managedclusteraddonstatus.go
@@ -49,7 +49,7 @@ func GetManagedClusterAddOnStatusMetricFamilies(getClusterIdFunc func(string) st
 				requiredAddOnStatusConditions,
 				getAllowedAddOnConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return &f
 		},
 	}

--- a/pkg/generators/cluster/managedclustercount.go
+++ b/pkg/generators/cluster/managedclustercount.go
@@ -30,7 +30,7 @@ func GetManagedClusterCountMetricFamilies() metric.FamilyGenerator {
 					Value: float64(count),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/cluster/managedclusterinfo.go
+++ b/pkg/generators/cluster/managedclusterinfo.go
@@ -120,7 +120,7 @@ product=%s`,
 					Value:       1,
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterlabels.go
+++ b/pkg/generators/cluster/managedclusterlabels.go
@@ -76,7 +76,7 @@ func GetManagedClusterLabelMetricFamilies(hubClusterID string) metric.FamilyGene
 				},
 			}}
 
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterstatus.go
+++ b/pkg/generators/cluster/managedclusterstatus.go
@@ -43,7 +43,7 @@ func GetManagedClusterStatusMetricFamilies() metric.FamilyGenerator {
 				requiredClusterStatusConditions,
 				getAllowedClusterConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclustertimestamp.go
+++ b/pkg/generators/cluster/managedclustertimestamp.go
@@ -43,7 +43,7 @@ func GetManagedClusterTimestampMetricFamilies(hubClusterID string,
 				values,
 				getClusterTimestamps,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterworkercores.go
+++ b/pkg/generators/cluster/managedclusterworkercores.go
@@ -55,7 +55,7 @@ core_worker=%d`,
 					Value:       float64(core_worker),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/work/manifestworkcount.go
+++ b/pkg/generators/work/manifestworkcount.go
@@ -29,7 +29,7 @@ func GetManifestWorkCountMetricFamilies() metric.FamilyGenerator {
 					Value: float64(count),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/work/manifestworkstatus.go
+++ b/pkg/generators/work/manifestworkstatus.go
@@ -50,7 +50,7 @@ func GetManifestWorkStatusMetricFamilies(getClusterIdFunc func(string) string) m
 				requiredWorkStatusConditions,
 				getAllowedManifestWorkConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return &f
 		},
 	}

--- a/pkg/generators/work/manifestworktimestamp.go
+++ b/pkg/generators/work/manifestworktimestamp.go
@@ -58,7 +58,7 @@ func GetManifestWorkTimestampMetricFamilies(getClusterIdFunc func(string) string
 					keys, values, generators.AppliedTimestamp))
 			}
 
-			klog.Infof("Returning %v", string(family.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(family.ByteSlice()))
 			return &family
 		},
 	}


### PR DESCRIPTION
## Summary
This PR updates all instances of `klog.Infof("Returning %v", ` to `klog.V(4).Infof("Returning %v", ` to improve log level control.

## Changes
- Modified 10 files across addon, work, and cluster generator packages
- Changed debug logging from always-on `klog.Infof()` to verbosity-controlled `klog.V(4).Infof()`
- This allows better control over debug output in production environments

## Benefits
- Reduces log noise in production when running with default log levels
- Debug output can still be enabled by setting appropriate verbosity level (--v=4)
- Maintains backward compatibility while improving operational experience

## Files Modified
- pkg/generators/addon/managedclusteraddonstatus.go
- pkg/generators/work/manifestworkcount.go
- pkg/generators/work/manifestworkstatus.go
- pkg/generators/work/manifestworktimestamp.go
- pkg/generators/cluster/managedclusterinfo.go
- pkg/generators/cluster/managedclusterlabels.go
- pkg/generators/cluster/managedclusterworkercores.go
- pkg/generators/cluster/managedclustertimestamp.go
- pkg/generators/cluster/managedclusterstatus.go
- pkg/generators/cluster/managedclustercount.go