### PR TITLE
Update klog verbosity level for debug output in backplane-2.6

### DIFF
--- a/pkg/generators/addon/managedclusteraddonstatus.go
+++ b/pkg/generators/addon/managedclusteraddonstatus.go
@@ -49,7 +49,7 @@ func GetManagedClusterAddOnStatusMetricFamilies(getClusterIdFunc func(string) st
 				requiredAddOnStatusConditions,
 				getAllowedAddOnConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return &f
 		},
 	}

--- a/pkg/generators/cluster/managedclustercount.go
+++ b/pkg/generators/cluster/managedclustercount.go
@@ -30,7 +30,7 @@ func GetManagedClusterCountMetricFamilies() metric.FamilyGenerator {
 					Value: float64(count),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/cluster/managedclusterinfo.go
+++ b/pkg/generators/cluster/managedclusterinfo.go
@@ -120,7 +120,7 @@ product=%s`,
 					Value:       1,
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterlabels.go
+++ b/pkg/generators/cluster/managedclusterlabels.go
@@ -76,7 +76,7 @@ func GetManagedClusterLabelMetricFamilies(hubClusterID string) metric.FamilyGene
 				},
 			}}
 
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterstatus.go
+++ b/pkg/generators/cluster/managedclusterstatus.go
@@ -43,7 +43,7 @@ func GetManagedClusterStatusMetricFamilies() metric.FamilyGenerator {
 				requiredClusterStatusConditions,
 				getAllowedClusterConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		}),
 	}

--- a/pkg/generators/cluster/managedclusterworkercores.go
+++ b/pkg/generators/cluster/managedclusterworkercores.go
@@ -50,7 +50,7 @@ core_worker=%d`,
 					Value:       float64(core_worker),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/work/manifestworkcount.go
+++ b/pkg/generators/work/manifestworkcount.go
@@ -29,7 +29,7 @@ func GetManifestWorkCountMetricFamilies() metric.FamilyGenerator {
 					Value: float64(count),
 				},
 			}}
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return f
 		},
 	}

--- a/pkg/generators/work/manifestworkstatus.go
+++ b/pkg/generators/work/manifestworkstatus.go
@@ -50,7 +50,7 @@ func GetManifestWorkStatusMetricFamilies(getClusterIdFunc func(string) string) m
 				requiredWorkStatusConditions,
 				getAllowedManifestWorkConditionStatuses,
 			)
-			klog.Infof("Returning %v", string(f.ByteSlice()))
+			klog.V(4).Infof("Returning %v", string(f.ByteSlice()))
 			return &f
 		},
 	}


### PR DESCRIPTION
## Summary
- Changed all instances of `klog.Infof("Returning %v",` to `klog.V(4).Infof("Returning %v",` to use verbosity level 4 for debug output
- This affects 8 files in the metrics generators package
- Improves logging control by allowing debug output to be controlled via verbosity flags

## Files Modified
- pkg/generators/addon/managedclusteraddonstatus.go
- pkg/generators/cluster/managedclusterinfo.go
- pkg/generators/cluster/managedclustercount.go
- pkg/generators/work/manifestworkcount.go
- pkg/generators/cluster/managedclusterlabels.go
- pkg/generators/cluster/managedclusterworkercores.go
- pkg/generators/work/manifestworkstatus.go
- pkg/generators/cluster/managedclusterstatus.go

## Test Plan
- [ ] Verify that debug output is properly controlled by verbosity level
- [ ] Ensure all existing functionality remains unchanged
- [ ] Test with different verbosity levels to confirm behavior