### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for clusterlifecycle-state-metrics-mce-29

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -15,7 +15,8 @@ RUN GOFLAGS="" go build ./cmd/clusterlifecycle-state-metrics; \
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
-    name="clusterlifecycle-state-metrics" \
+    name="multicluster-engine/clusterlifecycle-state-metrics-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="clusterlifecycle-state-metrics" \
     description="Cluster Lifecycle State Metrics generates a number of clusters related metrics used \
     for business analysis." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
