### PR TITLE
Add repository url label to container images

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -15,6 +15,7 @@ RUN GOFLAGS="" go build ./cmd/clusterlifecycle-state-metrics; \
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL \
+      url="https://github.com/stolostron/clusterlifecycle-state-metrics" \
     name="clusterlifecycle-state-metrics" \
     com.redhat.component="clusterlifecycle-state-metrics" \
     description="Cluster Lifecycle State Metrics generates a number of clusters related metrics used \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** clusterlifecycle-state-metrics

**Branch details:** clusterlifecycle-state-metrics (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/clusterlifecycle-state-metrics

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.