### PR TITLE
Fix Prometheus duplicate label error in managed cluster metrics

### DIFF
--- a/pkg/generators/cluster/managedclusterlabels.go
+++ b/pkg/generators/cluster/managedclusterlabels.go
@@ -41,6 +41,12 @@ func GetManagedClusterLabelMetricFamilies(hubClusterID string) metric.FamilyGene
 			nonWordRegex := regexp.MustCompile(`[^\w]+`) // Regex to check non-word characters
 			firstDigitRegex := regexp.MustCompile(`^\d`) // Regex to check if the first character is a digit
 
+			// Use a map to track already-used label keys for O(1) duplicate detection
+			usedKeys := make(map[string]bool, len(mc.Labels)+len(descManagedClusterLabelDefaultLabel))
+			for _, key := range descManagedClusterLabelDefaultLabel {
+				usedKeys[key] = true
+			}
+
 			for key, value := range mc.Labels {
 				// Ignore the clusterID label since it is being set within the hub and managed cluster IDs
 				if key != "clusterID" {
@@ -57,6 +63,13 @@ func GetManagedClusterLabelMetricFamilies(hubClusterID string) metric.FamilyGene
 						modifiedKey = "_" + modifiedKey
 					}
 
+					// Check for duplicate label names to prevent invalid Prometheus metrics
+					if usedKeys[modifiedKey] {
+						klog.Warningf("Skipping label '%s' (would convert to '%s') - conflicts with existing label. This may indicate duplicate labels on ManagedCluster '%s'",
+							originalKey, modifiedKey, mc.GetName())
+						continue // Skip this label to avoid Prometheus duplicate label error
+					}
+
 					// If the key was converted, log a warning
 					if originalKey != modifiedKey {
 						klog.Infof("Label key '%s' was converted to '%s' since it contains non-word characters or a first digit", originalKey, modifiedKey)
@@ -65,6 +78,7 @@ func GetManagedClusterLabelMetricFamilies(hubClusterID string) metric.FamilyGene
 					// Add the modified key and value to the label slices
 					labelsKeys = append(labelsKeys, modifiedKey)
 					labelsValues = append(labelsValues, value)
+					usedKeys[modifiedKey] = true
 				}
 			}
 

--- a/pkg/generators/cluster/managedclusterlabels_test.go
+++ b/pkg/generators/cluster/managedclusterlabels_test.go
@@ -53,7 +53,23 @@ func Test_getManagedClusterLabelMetricFamilies(t *testing.T) {
 				mciv1beta1.LabelClusterID: "managed_cluster_id",
 				"5g-dev01-cluster":        "value1",
 				"55g//dev01__cluster":     "value2",
-				"_5g-dev01_cluster":       "value3",
+			},
+		},
+		Status: mcv1.ManagedClusterStatus{
+			Capacity:      mcv1.ResourceList{},
+			ClusterClaims: []mcv1.ManagedClusterClaim{},
+			Conditions:    []metav1.Condition{},
+		},
+	}
+
+	mc4 := &mcv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster-duplicate-labels",
+			Labels: map[string]string{
+				mciv1beta1.LabelClusterID: "managed_cluster_id",
+				"cluster-elm-sa-name":     "ymo",
+				"cluster.elm.sa/name":     "ymo",
+				"cloud":                   "gcp",
 			},
 		},
 		Status: mcv1.ManagedClusterStatus{
@@ -80,7 +96,13 @@ func Test_getManagedClusterLabelMetricFamilies(t *testing.T) {
 			Name:        "test cluster3 label",
 			Obj:         mc3,
 			MetricNames: []string{"acm_managed_cluster_labels"},
-			Want:        `acm_managed_cluster_labels{managed_cluster_id="managed_cluster_id",hub_cluster_id="hub_cluster_id",_5g_dev01_cluster="value1",_55g_dev01__cluster="value2",_5g_dev01_cluster="value3"} 1`,
+			Want:        `acm_managed_cluster_labels{managed_cluster_id="managed_cluster_id",hub_cluster_id="hub_cluster_id",_5g_dev01_cluster="value1",_55g_dev01__cluster="value2"} 1`,
+		},
+		{
+			Name:        "test cluster with duplicate labels after conversion",
+			Obj:         mc4,
+			MetricNames: []string{"acm_managed_cluster_labels"},
+			Want:        `acm_managed_cluster_labels{managed_cluster_id="managed_cluster_id",hub_cluster_id="hub_cluster_id",cluster_elm_sa_name="ymo",cloud="gcp"} 1`,
 		},
 	}
 


### PR DESCRIPTION
Prevents invalid Prometheus metrics when multiple ManagedCluster labels convert to the same sanitized name (e.g., 'cluster-elm-sa-name' and 'cluster.elm.sa/name' both become 'cluster_elm_sa_name'). Uses a hash map for O(1) duplicate detection instead of O(n²) linear search. Adds warning logs when duplicate labels are skipped.

Fixes the issue where Prometheus fails to scrape metrics with error: "label name 'cluster_elm_sa_name' is not unique: invalid sample"

Related: https://redhat.atlassian.net/browse/ACM-32021 