### PR TITLE
update to golang1.26

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25
+          go-version-file: go.mod
 
       - name: Functional Tests
         run: make functional-test-full

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 ARG REMOTE_SOURCE
 ARG REMOTE_SOURCE_DIR

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 # This dockerfile only used in middle stream build, without downloading and building APISERVER_NETWORK_PROXY_VERSION
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as builder
 
 WORKDIR /workspace
 COPY . .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -17,7 +17,6 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \
       url="https://github.com/stolostron/clusterlifecycle-state-metrics" \
     name="multicluster-engine/clusterlifecycle-state-metrics-rhel9" \
-    cpe="cpe:/a:redhat:multicluster_engine:2.11::el9" \
     com.redhat.component="clusterlifecycle-state-metrics" \
     description="Cluster Lifecycle State Metrics generates a number of clusters related metrics used \
     for business analysis." \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/clusterlifecycle-state-metrics
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2


### PR DESCRIPTION
Also removes the old incorrect cpe value from Dockerfile.rhap - the cpe label will be inserted automatically by the common pipeline.